### PR TITLE
fix: add relative paths to package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,20 +3,20 @@
     "description": "Add .js or .mjs extension to each relative ESM import and export statement in JavaScript file",
     "version": "1.4.0",
     "license": "MIT",
-    "main": "build/cjs/index.js",
-    "module": "build/mjs/index.js",
-    "types": "build/cjs/index.d.ts",
-    "react-native": "build/mjs/index.js",
+    "main": "./build/cjs/index.js",
+    "module": "./build/mjs/index.js",
+    "types": "./build/cjs/index.d.ts",
+    "react-native": "./build/mjs/index.js",
     "exports": {
-        "./package.json": "package.json",
+        "./package.json": "./package.json",
         ".": {
-            "require": "build/cjs/index.js",
-            "import": "build/mjs/index.js",
-            "default": "build/mjs/index.js"
+            "require": "./build/cjs/index.js",
+            "import": "./build/mjs/index.js",
+            "default": "./build/mjs/index.js"
         }
     },
     "bin": {
-        "ts-add-js-extension": "build/cjs/bin.js"
+        "ts-add-js-extension": "./build/cjs/bin.js"
     },
     "files": [
         "build"


### PR DESCRIPTION
This fixes this error after installing to latest version and trying to consume the package from ESM:

```
Error [ERR_INVALID_PACKAGE_TARGET]: Invalid "exports" main target "build/cjs/index.js" defined in the package config /Users/elkevinwolf/projects/github.com/kevinwolfcr/prestawise/repos/ts-kit/node_modules/ts-add-js-extension/package.json; targets must start with "./"
```