### PR TITLE
Bugfix: append, don't replace, fetched data on data receipt events

### DIFF
--- a/src/read-write.ts
+++ b/src/read-write.ts
@@ -31,7 +31,7 @@ const readCode = (file: string) => {
 
 		fs.createReadStream(file)
 			.on('data', (data) => {
-				fetchData = data.toString();
+				fetchData += data.toString();
 			})
 			.on('end', () => {
 				resolve(fetchData);


### PR DESCRIPTION
This change fixes a bug where, when there are multiple "data" events while reading the stream, the previous data gets replaced rather than appended.

There are more optimal ways to manage the data chunks (an array of strings joined at the end), but this is a minimal change to fix the logic.