### PR TITLE
fix missing typeArgument in dynamic type import

### DIFF
--- a/src/traverse-and-update.ts
+++ b/src/traverse-and-update.ts
@@ -262,7 +262,7 @@ const dynamicDtsImport = (
 				),
 				node.attributes,
 				node.qualifier,
-				undefined,
+				node.typeArguments,
 				node.isTypeOf
 			);
 		}

--- a/test/process/expected-result/dts/dts-only/dynamic-import-typeargs.d.ts
+++ b/test/process/expected-result/dts/dts-only/dynamic-import-typeargs.d.ts
@@ -1,0 +1,1 @@
+type WithTypeArgs = import("./utils/index.js").GenericType<import("./utils/index.js").Stack>;

--- a/test/process/source/dts/dts-only/dynamic-import-typeargs.d.ts
+++ b/test/process/source/dts/dts-only/dynamic-import-typeargs.d.ts
@@ -1,0 +1,1 @@
+type WithTypeArgs = import('./utils').GenericType<import('./utils').Stack>;


### PR DESCRIPTION
typeArguments of type import is missing now. see below
![screenshot-20250510-171426](https://github.com/user-attachments/assets/5971a0dd-9363-4cab-b40a-576d20324922)

add parameter to `updateImportTypeNode` fix this issue